### PR TITLE
Named mounting (only affects OSX atm)

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/model/Directory.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/model/Directory.java
@@ -86,7 +86,7 @@ public class Directory implements Serializable {
 			return false;
 		}
 		try {
-			webDavMount = WebDavMounter.mount(webDavServlet.getServletUri());
+			webDavMount = WebDavMounter.mount(webDavServlet.getServletUri(), getMountName());
 			return true;
 		} catch (CommandFailedException e) {
 			LOG.warn("mount failed", e);

--- a/main/ui/src/main/java/org/cryptomator/ui/util/mount/FallbackWebDavMounter.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/util/mount/FallbackWebDavMounter.java
@@ -23,7 +23,7 @@ final class FallbackWebDavMounter implements WebDavMounterStrategy {
 	}
 
 	@Override
-	public WebDavMount mount(URI uri) {
+	public WebDavMount mount(URI uri, String name) {
 		displayMountInstructions();
 		return new WebDavMount() {
 			@Override

--- a/main/ui/src/main/java/org/cryptomator/ui/util/mount/LinuxGvfsWebDavMounter.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/util/mount/LinuxGvfsWebDavMounter.java
@@ -32,7 +32,7 @@ final class LinuxGvfsWebDavMounter implements WebDavMounterStrategy {
 	}
 
 	@Override
-	public WebDavMount mount(URI uri) throws CommandFailedException {
+	public WebDavMount mount(URI uri, String name) throws CommandFailedException {
 		final Script mountScript = Script.fromLines(
 				"set -x",
 				"gvfs-mount \"dav:$DAV_SSP\"",

--- a/main/ui/src/main/java/org/cryptomator/ui/util/mount/MacOsXWebDavMounter.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/util/mount/MacOsXWebDavMounter.java
@@ -22,15 +22,16 @@ final class MacOsXWebDavMounter implements WebDavMounterStrategy {
 	}
 
 	@Override
-	public WebDavMount mount(URI uri) throws CommandFailedException {
+	public WebDavMount mount(URI uri, String name) throws CommandFailedException {
 		final String path = "/Volumes/Cryptomator" + uri.getRawPath().replace('/', '_');
 		final Script mountScript = Script.fromLines(
 				"mkdir \"$MOUNT_PATH\"",
-				"mount_webdav -S -v Cryptomator \"[::1]:$PORT$DAV_PATH\" \"$MOUNT_PATH\"",
+				"mount_webdav -S -v $MOUNT_NAME \"[::1]:$PORT$DAV_PATH\" \"$MOUNT_PATH\"",
 				"open \"$MOUNT_PATH\"")
 				.addEnv("PORT", String.valueOf(uri.getPort()))
 				.addEnv("DAV_PATH", uri.getRawPath())
-				.addEnv("MOUNT_PATH", path);
+				.addEnv("MOUNT_PATH", path)
+				.addEnv("MOUNT_NAME", name);
 		final Script unmountScript = Script.fromLines(
 				"umount $MOUNT_PATH")
 				.addEnv("MOUNT_PATH", path);

--- a/main/ui/src/main/java/org/cryptomator/ui/util/mount/WebDavMounter.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/util/mount/WebDavMounter.java
@@ -26,11 +26,12 @@ public final class WebDavMounter {
 	 * Tries to mount a given webdav share.
 	 * 
 	 * @param uri URI of the webdav share
+	 * @param name the name under which the folder is to be mounted. This might be ignored.
 	 * @return a {@link WebDavMount} representing the mounted share
 	 * @throws CommandFailedException if the mount operation fails
 	 */
-	public static WebDavMount mount(URI uri) throws CommandFailedException {
-		return chooseStrategy().mount(uri);
+	public static WebDavMount mount(URI uri, String name) throws CommandFailedException {
+		return chooseStrategy().mount(uri, name);
 	}
 
 	private static WebDavMounterStrategy chooseStrategy() {

--- a/main/ui/src/main/java/org/cryptomator/ui/util/mount/WebDavMounterStrategy.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/util/mount/WebDavMounterStrategy.java
@@ -27,9 +27,10 @@ interface WebDavMounterStrategy {
 	 * Tries to mount a given webdav share.
 	 * 
 	 * @param uri URI of the webdav share
+	 * @param name the name under which the folder is to be mounted. This might be ignored.
 	 * @return a {@link WebDavMount} representing the mounted share
 	 * @throws CommandFailedException if the mount operation fails
 	 */
-	WebDavMount mount(URI uri) throws CommandFailedException;
+	WebDavMount mount(URI uri, String name) throws CommandFailedException;
 
 }

--- a/main/ui/src/main/java/org/cryptomator/ui/util/mount/WindowsWebDavMounter.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/util/mount/WindowsWebDavMounter.java
@@ -37,7 +37,7 @@ final class WindowsWebDavMounter implements WebDavMounterStrategy {
 	}
 
 	@Override
-	public WebDavMount mount(URI uri) throws CommandFailedException {
+	public WebDavMount mount(URI uri, String name) throws CommandFailedException {
 		final Script mountScript = fromLines("net use * http://0--1.ipv6-literal.net:%PORT%%DAV_PATH% /persistent:no")
 				.addEnv("PORT", String.valueOf(uri.getPort()))
 				.addEnv("DAV_PATH", uri.getRawPath());


### PR DESCRIPTION
Added the new mount name to the web dav mounter interface. Under OSX, we can now use the name, which fixes #5